### PR TITLE
Add About and Rooms sections to generated site

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -40,7 +40,7 @@ async def generate(request: Request, prompt: str = Form(...)):
     system_message = (
         "You generate short JSON snippets for a hotel landing page. "
         "Return only JSON with keys: title, hero_heading, hero_text, "
-        "about_heading, about_text.")
+        "about_heading, about_text, rooms_heading, rooms_text.")
     user_message = f"User description: {prompt}"
     response = client.chat.completions.create(
         model="gpt-3.5-turbo",

--- a/templates/page.html
+++ b/templates/page.html
@@ -37,9 +37,18 @@
     </style>
 </head>
 <body>
+    <div id="top"></div>
     <nav class="navbar navbar-expand-lg navbar-dark">
         <div class="container">
-            <span class="navbar-brand">{{ title }}</span>
+            <a class="navbar-brand" href="#top">{{ title }}</a>
+            <ul class="navbar-nav ms-auto">
+                <li class="nav-item">
+                    <a class="nav-link" href="#about">About</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="#rooms">Available Rooms</a>
+                </li>
+            </ul>
         </div>
     </nav>
 
@@ -52,6 +61,13 @@
         <div class="container">
             <h2>{{ about_heading }}</h2>
             <p>{{ about_text }}</p>
+        </div>
+    </section>
+
+    <section class="content-section" id="rooms">
+        <div class="container">
+            <h2>{{ rooms_heading }}</h2>
+            <p>{{ rooms_text }}</p>
         </div>
     </section>
 


### PR DESCRIPTION
## Summary
- expand system prompt so OpenAI returns heading/text for an available rooms section
- add links in the navbar for About and Available Rooms
- include new sections in the single-page template

## Testing
- `python -m py_compile backend/main.py`