### PR TITLE
Improve home page with larger previews

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -32,7 +32,7 @@ templates = Jinja2Templates(directory='templates')
 # Home page: display form and list of generated sites
 @app.get('/', response_class=HTMLResponse)
 async def index(request: Request):
-    return templates.TemplateResponse('index.html', {'request': request, 'sites': sites_data})
+    return templates.TemplateResponse('index.html', {'request': request, 'sites': list(reversed(sites_data))})
 
 # POST endpoint to generate site using OpenAI
 @app.post('/generate', response_class=HTMLResponse)

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,24 +4,38 @@
     <meta charset="UTF-8">
     <title>Website Builder</title>
     <link rel="stylesheet" href="/static/bootstrap.min.css">
+    <style>
+        iframe {
+            border: 0;
+            width: 100%;
+        }
+    </style>
 </head>
 <body class="container py-4">
-<h1 class="mb-4">Hotel Website Generator</h1>
-<form method="post" action="/generate">
+<h1 class="mb-4 text-center">Hotel Website Generator</h1>
+<form method="post" action="/generate" class="mb-5">
     <div class="mb-3">
         <label for="prompt" class="form-label">Describe your hotel website:</label>
         <textarea class="form-control" id="prompt" name="prompt" rows="4" required placeholder='Describe your site. Include the hotel name after the text "hotel name:"'></textarea>
     </div>
     <button type="submit" class="btn btn-primary">Generate</button>
 </form>
-<hr>
-<h2>Previously Generated Sites</h2>
-<ul>
+<h2 class="mb-3">Previously Generated Sites</h2>
+<div class="row row-cols-1 row-cols-md-2 g-5">
     {% for site in sites %}
-    <li><a href="/sites/{{ site.file }}" target="_blank">{{ site.file }}</a> - {{ site.prompt }}</li>
+    <div class="col">
+        <div class="card h-100 shadow-sm">
+            <iframe src="/sites/{{ site.file }}" class="card-img-top" height="300"></iframe>
+            <div class="card-body">
+                <h5 class="card-title">{{ site.file }}</h5>
+                <p class="card-text">{{ site.prompt }}</p>
+                <a href="/sites/{{ site.file }}" target="_blank" class="btn btn-primary btn-sm">Open Site</a>
+            </div>
+        </div>
+    </div>
     {% else %}
-    <li>No sites generated yet.</li>
+    <p>No sites generated yet.</p>
     {% endfor %}
-</ul>
+</div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- increase iframe width and height for site previews
- display previews in a two-column layout with extra spacing

## Testing
- `python -m py_compile backend/main.py`
