### PR TITLE
Add template selection and previews

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -8,6 +8,7 @@ import json
 from datetime import datetime
 import re
 import shutil
+import base64
 
 app = FastAPI()
 
@@ -36,7 +37,7 @@ async def index(request: Request):
 
 # POST endpoint to generate site using OpenAI
 @app.post('/generate', response_class=HTMLResponse)
-async def generate(request: Request, prompt: str = Form(...)):
+async def generate(request: Request, prompt: str = Form(...), template: str = Form('hotel')):
     """Generate website HTML/CSS/JS using OpenAI based on user prompt."""
     client = openai.OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
     system_message = (
@@ -63,7 +64,8 @@ async def generate(request: Request, prompt: str = Form(...)):
         response_format={"type": "json_object"},
     )
     data = json.loads(response.choices[0].message.content)
-    content = templates.get_template('hotel.html').render(**data)
+    template_file = 'hotel.html' if template == 'hotel' else 'lifestyle.html'
+    content = templates.get_template(template_file).render(**data)
 
     timestamp = datetime.utcnow().strftime('%Y%m%d%H%M%S')
     # extract hotel name after "hotel name:" and slugify
@@ -80,24 +82,43 @@ async def generate(request: Request, prompt: str = Form(...)):
         f.write(content)
 
     # copy required assets into the folder
-    image_map = {
-        'hero-bg.webp': 'spa-hotel-hero-768x352.webp',
-        'casino-bg.webp': 'casino-hotels-6-768x358.webp',
-        'hotel1.webp': 'Casino-Hotels-4-150x150.webp',
-        'hotel2.webp': 'Casino-Hotels-5-150x150.webp',
-        'hotel3.jpg': 'pexels-olly-3786784-300x200.jpg',
-        'hotel4.jpg': 'pexels-olly-3786784-768x512.jpg',
-        'retreat1.webp': '21-Club-Steak-Seafood-300x104.webp',
-        'retreat2.webp': 'Baccarat-300x104.webp',
-        'waterside.webp': 'Banff-Caribou-Lodge-300x224.webp',
-        'forest.webp': 'Bar-Barista-1-300x125.webp',
-        'playstay.webp': 'Blackjack-150x150.webp',
-        'casino-royale.webp': 'Casino-Hotels-5.webp',
-    }
-    for dest, src in image_map.items():
-        src_path = os.path.join('assets', src)
-        if os.path.exists(src_path):
-            shutil.copy(src_path, os.path.join(folder_path, dest))
+    if template == 'hotel':
+        image_map = {
+            'hero-bg.webp': 'spa-hotel-hero-768x352.webp',
+            'casino-bg.webp': 'casino-hotels-6-768x358.webp',
+            'hotel1.webp': 'Casino-Hotels-4-150x150.webp',
+            'hotel2.webp': 'Casino-Hotels-5-150x150.webp',
+            'hotel3.jpg': 'pexels-olly-3786784-300x200.jpg',
+            'hotel4.jpg': 'pexels-olly-3786784-768x512.jpg',
+            'retreat1.webp': '21-Club-Steak-Seafood-300x104.webp',
+            'retreat2.webp': 'Baccarat-300x104.webp',
+            'waterside.webp': 'Banff-Caribou-Lodge-300x224.webp',
+            'forest.webp': 'Bar-Barista-1-300x125.webp',
+            'playstay.webp': 'Blackjack-150x150.webp',
+            'casino-royale.webp': 'Casino-Hotels-5.webp',
+        }
+        for dest, src in image_map.items():
+            src_path = os.path.join('assets', 'hotel', src)
+            if os.path.exists(src_path):
+                shutil.copy(src_path, os.path.join(folder_path, dest))
+    else:
+        lifestyle_imgs = [
+            'hero-baby.jpg', 'mri.jpg', 'stretch.jpg', 'ransomware.jpg',
+            'xbox.jpg', 'console.jpg', 'netflix.jpg', 'ipad.jpg',
+            'elderly-dog.jpg', 'rabbit.jpg', 'aquarium.jpg',
+            'ps5-vs-xbox.jpg', 'gaming-console.jpg'
+        ]
+        placeholder = base64.b64decode(
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+g8AAwUBAO+jbmwAAAAASUVORK5CYII='
+        )
+        for name in lifestyle_imgs:
+            src_path = os.path.join('assets', 'lifestyle', name)
+            dest_path = os.path.join(folder_path, name)
+            if os.path.exists(src_path):
+                shutil.copy(src_path, dest_path)
+            else:
+                with open(dest_path, 'wb') as f:
+                    f.write(placeholder)
 
     # create simple svg icons
     icons = {
@@ -129,3 +150,51 @@ async def generate(request: Request, prompt: str = Form(...)):
     with open(DATA_FILE, 'w') as f:
         json.dump(sites_data, f)
     return templates.TemplateResponse('generated.html', {'request': request, 'file': site_entry})
+
+
+@app.get('/preview/{template}', response_class=HTMLResponse)
+async def preview_template(template: str):
+    if template not in {'hotel', 'lifestyle'}:
+        return HTMLResponse('Template not found', status_code=404)
+
+    demo = {
+        'title': 'Demo Site',
+        'hero_heading': 'Welcome!',
+        'hero_text': 'Sample hero text.',
+        'tagline_heading': 'Tagline',
+        'tagline_text': 'Short description.',
+        'feature1_title': 'Feature 1',
+        'feature1_text': 'Feature 1 text',
+        'feature2_title': 'Feature 2',
+        'feature2_text': 'Feature 2 text',
+        'feature3_title': 'Feature 3',
+        'feature3_text': 'Feature 3 text',
+        'feature4_title': 'Feature 4',
+        'feature4_text': 'Feature 4 text',
+        'casino_heading': 'Casino Fun',
+        'casino_text': 'Casino description',
+        'link1_title': 'Link 1',
+        'link2_title': 'Link 2',
+        'extended1_title': 'Ext 1',
+        'extended1_text': 'Ext 1 text',
+        'extended1_button': 'Read',
+        'extended2_title': 'Ext 2',
+        'extended2_text': 'Ext 2 text',
+        'extended2_button': 'Read',
+        'extended3_title': 'Ext 3',
+        'extended3_text': 'Ext 3 text',
+        'extended3_button': 'Read',
+        'extended4_title': 'Ext 4',
+        'extended4_text': 'Ext 4 text',
+        'extended4_button': 'Read',
+        'benefits_heading': 'Benefits',
+        'benefit1_title': 'Benefit 1',
+        'benefit1_text': 'Benefit 1 text',
+        'benefit2_title': 'Benefit 2',
+        'benefit2_text': 'Benefit 2 text',
+        'benefit3_title': 'Benefit 3',
+        'benefit3_text': 'Benefit 3 text',
+    }
+    template_file = 'hotel.html' if template == 'hotel' else 'lifestyle.html'
+    html = templates.get_template(template_file).render(**demo)
+    return HTMLResponse(html)

--- a/templates/index.html
+++ b/templates/index.html
@@ -58,8 +58,30 @@
         <label for="prompt" class="form-label">Describe your hotel website:</label>
         <textarea class="form-control" id="prompt" name="prompt" rows="4" required placeholder='Describe your site. Include the hotel name after the text "hotel name:"'></textarea>
     </div>
+    <div class="mb-3">
+        <label class="form-label d-block">Choose Template:</label>
+        <div class="form-check form-check-inline">
+            <input class="form-check-input" type="radio" name="template" id="templateHotel" value="hotel" checked>
+            <label class="form-check-label" for="templateHotel">Hotel</label>
+        </div>
+        <div class="form-check form-check-inline">
+            <input class="form-check-input" type="radio" name="template" id="templateLifestyle" value="lifestyle">
+            <label class="form-check-label" for="templateLifestyle">Lifestyle</label>
+        </div>
+    </div>
     <button type="submit" class="btn btn-primary">Generate</button>
 </form>
+
+<div class="row mb-5">
+    <div class="col-md-6">
+        <h5 class="text-center">Hotel Preview</h5>
+        <iframe src="/preview/hotel" style="height:40vh;"></iframe>
+    </div>
+    <div class="col-md-6 mt-3 mt-md-0">
+        <h5 class="text-center">Lifestyle Preview</h5>
+        <iframe src="/preview/lifestyle" style="height:40vh;"></iframe>
+    </div>
+</div>
 <h2 class="mb-3 text-center">Previously Generated Sites</h2>
 {% for site in sites %}
 <div class="preview-section shadow-sm">

--- a/templates/lifestyle.html
+++ b/templates/lifestyle.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Health & Lifestyle Blog</title>
+  <title>{{ title }}</title>
   <style>
     * {
   margin: 0;
@@ -204,7 +204,7 @@ body {
 <body>
 
   <header class="site-header">
-    <div class="logo">GLASS CRADLE</div>
+    <div class="logo">{{ title }}</div>
     <nav class="nav-menu">
       <a href="#">Lifestyle</a>
       <a href="#">Health</a>
@@ -215,28 +215,28 @@ body {
 
   <main class="main-content">
     <section class="hero-article">
-      <img src="hero-baby.jpg" alt="Baby Temperature">
+      <img src="hero-baby.jpg" alt="Hero Image">
       <div class="overlay-text">
         <span class="category">Health</span>
-        <h1>Knowing and Managing a Low Body Temperature in Babies</h1>
-        <p class="meta">By Nancy Ward · May 17, 2025</p>
+        <h1>{{ hero_heading }}</h1>
+        <p class="meta">{{ hero_text }}</p>
       </div>
     </section>
 
     <section class="article-grid">
       <div class="section-left">
-        <h2 class="section-title">Health</h2>
+        <h2 class="section-title">{{ tagline_heading }}</h2>
         <div class="grid-row">
           <div class="article-card">
-            <img src="mri.jpg" alt="Migraine">
-            <h3>Signs It’s Time to Find A New Migraine Doctor</h3>
-            <p>Most people have sessions with headache clinics and specialists before settling down with...</p>
+            <img src="mri.jpg" alt="Article 1">
+            <h3>{{ feature1_title }}</h3>
+            <p>{{ feature1_text }}</p>
             <a href="#" class="read-more">Read More</a>
           </div>
           <div class="article-card">
-            <img src="stretch.jpg" alt="Massage">
-            <h3>When Should You Consider Sports Massage?</h3>
-            <p>There are huge health benefits for anyone who takes up regular physical activity...</p>
+            <img src="stretch.jpg" alt="Article 2">
+            <h3>{{ feature2_title }}</h3>
+            <p>{{ feature2_text }}</p>
             <a href="#" class="read-more">Read More</a>
           </div>
         </div>
@@ -248,110 +248,109 @@ body {
           <li>
             <img src="ransomware.jpg" alt="">
             <div>
-              <p class="link">Damages and Dilemma Caused by Ransomware Attacks</p>
-              <small>May 18, 2025</small>
+              <p class="link">{{ feature3_title }}</p>
+              <small>{{ feature3_text }}</small>
             </div>
           </li>
           <li>
             <img src="xbox.jpg" alt="">
             <div>
-              <p class="link">How PS5 Differentiated Itself From Xbox Series X</p>
-              <small>May 18, 2025</small>
+              <p class="link">{{ feature4_title }}</p>
+              <small>{{ feature4_text }}</small>
             </div>
           </li>
           <li>
             <img src="console.jpg" alt="">
             <div>
-              <p class="link">Battle For The Ultimate Next-Generation Console</p>
-              <small>May 18, 2025</small>
+              <p class="link">{{ link1_title }}</p>
+              <small>{{ link2_title }}</small>
             </div>
           </li>
           <li>
             <img src="netflix.jpg" alt="">
             <div>
-              <p class="link">3 Top Ways to Stream Netflix on TV Screen</p>
-              <small>May 18, 2025</small>
+              <p class="link">{{ extended1_title }}</p>
+              <small>{{ extended1_text }}</small>
             </div>
           </li>
           <li>
             <img src="ipad.jpg" alt="">
             <div>
-              <p class="link">Differences Between iPad And Fire Tablet You Should Know</p>
-              <small>May 17, 2025</small>
+              <p class="link">{{ extended2_title }}</p>
+              <small>{{ extended2_text }}</small>
             </div>
           </li>
         </ul>
       </aside>
     </section>
 
-    <section class="content-section">
-  <h2 class="section-title">Lifestyle</h2>
+<section class="content-section">
+  <h2 class="section-title">{{ extended1_title }}</h2>
   <div class="grid-row">
-    <!-- Repeat articles from Lifestyle -->
     <div class="article-card">
       <img src="ransomware.jpg" alt="">
-      <h3>Damages and Dilemma Caused by Ransomware Attacks</h3>
-      <p>The attackers have adapted a new method called double distortion...</p>
-      <a href="#" class="read-more">Read More</a>
+      <h3>{{ extended1_title }}</h3>
+      <p>{{ extended1_text }}</p>
+      <a href="#" class="read-more">{{ extended1_button }}</a>
     </div>
     <div class="article-card">
       <img src="mri.jpg" alt="">
-      <h3>Signs It’s Time To Find A New Migraine Doctor</h3>
-      <p>Most people have sessions with specialists before settling down...</p>
-      <a href="#" class="read-more">Read More</a>
+      <h3>{{ extended2_title }}</h3>
+      <p>{{ extended2_text }}</p>
+      <a href="#" class="read-more">{{ extended2_button }}</a>
     </div>
     <div class="article-card">
       <img src="stretch.jpg" alt="">
-      <h3>When Should You Consider Sports Massage?</h3>
-      <p>There are huge health benefits for anyone who takes up physical activity...</p>
-      <a href="#" class="read-more">Read More</a>
+      <h3>{{ extended3_title }}</h3>
+      <p>{{ extended3_text }}</p>
+      <a href="#" class="read-more">{{ extended3_button }}</a>
     </div>
   </div>
 </section>
 
 <section class="content-section">
-  <h2 class="section-title">Pets</h2>
+  <h2 class="section-title">{{ extended4_title }}</h2>
   <div class="grid-row">
     <div class="article-card">
       <img src="elderly-dog.jpg" alt="">
-      <h3>The Best Pets For Your Elderly Parents</h3>
-      <p>If you are fit enough to care for yourself, you are fit enough for a dog...</p>
+      <h3>{{ benefit1_title }}</h3>
+      <p>{{ benefit1_text }}</p>
       <a href="#" class="read-more">Read More</a>
     </div>
     <div class="article-card">
       <img src="rabbit.jpg" alt="">
-      <h3>Loss of Appetite in Pet Rabbits</h3>
-      <p>Rabbits need to feed regularly; it's essential to provide them with...</p>
+      <h3>{{ benefit2_title }}</h3>
+      <p>{{ benefit2_text }}</p>
       <a href="#" class="read-more">Read More</a>
     </div>
     <div class="article-card">
       <img src="aquarium.jpg" alt="">
-      <h3>Buying The Right Aquarium For A Child Or A Teen</h3>
-      <p>Watching fish swim in an aquarium can relieve stress and calm nerves...</p>
+      <h3>{{ benefit3_title }}</h3>
+      <p>{{ benefit3_text }}</p>
       <a href="#" class="read-more">Read More</a>
     </div>
   </div>
 </section>
 
 <section class="content-section">
-  <h2 class="section-title">Tech</h2>
+  <h2 class="section-title">{{ casino_heading }}</h2>
   <div class="grid-row">
     <div class="article-card">
       <img src="ransomware.jpg" alt="">
-      <h3>Damages and Dilemma Caused by Ransomware Attacks</h3>
-      <p>New double distortion methods are putting pressure on companies...</p>
+      <h3>{{ casino_heading }}</h3>
+      <p>{{ casino_text }}</p>
       <a href="#" class="read-more">Read More</a>
     </div>
     <div class="article-card">
       <img src="ps5-vs-xbox.jpg" alt="">
-      <h3>How PS5 Differentiated Itself From Xbox Series X</h3>
-      <p>Both are new-gen consoles, but PS5 made key power and design moves...</p>
+      <h3>{{ link1_title }}</h3>
+      <p>{{ extended4_text }}</p>
       <a href="#" class="read-more">Read More</a>
     </div>
     <div class="article-card">
       <img src="gaming-console.jpg" alt="">
-      <h3>Battle For The Ultimate Next-Generation Console</h3>
-      <p>Visuals, performance, and immersion — which console takes the crown?</p>
+      <h3>{{ link2_title }}</h3>
+      <p>{{ tagline_text }}</p>
       <a href="#" class="read-more">Read More</a>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add template selection radio buttons with previews on the homepage
- allow backend to generate sites using either `hotel.html` or `lifestyle.html`
- provide `/preview/{template}` endpoint for iframe previews
- update `lifestyle.html` with Jinja placeholders so it can be filled with AI data

## Testing
- `python3 -m py_compile backend/main.py`
- `python3 -m py_compile $(git ls-files '*.py')`
