### PR TITLE
Improve preview spacing and use full bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This proof of concept demonstrates a very simple hotel website generator. A Fast
    ```
 3. Open `http://localhost:8085` in your browser.
 
-Generated sites are saved in the `generated_sites/` folder. A minimal Bootstrap CSS file is included in `static/` for offline use. Each site now contains an `assets/` subfolder holding its images and icons. The HTML layout lives in `templates/hotel.html`; OpenAI only supplies the text content inserted into that template.
+Generated sites are saved in the `generated_sites/` folder. The full Bootstrap library is bundled in `static/bootstrap/` and can be copied into generated sites if desired. Each site now contains an `assets/` subfolder holding its images and icons. The HTML layout lives in `templates/hotel.html`; OpenAI only supplies the text content inserted into that template.
 OpenAI now returns text for many sections such as feature cards and benefits which populate this template.
 
 ### Hero Images

--- a/templates/generated.html
+++ b/templates/generated.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Site Generated</title>
-    <link rel="stylesheet" href="/static/bootstrap.min.css">
+    <link rel="stylesheet" href="/static/bootstrap/css/bootstrap.min.css">
 </head>
 <body class="container py-4">
 <h1>Your website has been generated!</h1>

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <title>Website Builder</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="/static/bootstrap.min.css">
+    <link rel="stylesheet" href="/static/bootstrap/css/bootstrap.min.css">
     <style>
         body {
             background-color: #343541;
@@ -117,7 +117,7 @@
     </div>
 </div>
 
-<div class="row mb-5 g-4">
+<div class="row mb-5 g-5">
     <div class="col-md-6">
         <div class="preview-card">
             <h5 class="text-center">Hotel Preview</h5>

--- a/templates/page.html
+++ b/templates/page.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ title }}</title>
-    <link rel="stylesheet" href="/static/bootstrap.min.css">
+    <link rel="stylesheet" href="/static/bootstrap/css/bootstrap.min.css">
     <style>
         body {
             font-family: Arial, sans-serif;


### PR DESCRIPTION
## Summary
- load the full Bootstrap library from `static/bootstrap`
- widen the gap between the template previews
- update `generated.html` and `page.html` to use the new Bootstrap path
- document the new library location in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`