### PR TITLE
Ensure hero image for lifestyle template

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,6 @@ OpenAI now returns text for many sections such as feature cards and benefits whi
 
 When selecting a hero image for a site, choose a file that is at least **300 KB**. Images smaller than this may appear grainy when used full width.
 
+For the **lifestyle** template the hero image is fixed to `hero_1.jpg`. This file is automatically copied into each generated site that uses the lifestyle template.
+
 OPENAI_API_KEY=your-key-here uvicorn backend.main:app --reload

--- a/backend/main.py
+++ b/backend/main.py
@@ -111,6 +111,11 @@ async def generate(request: Request, prompt: str = Form(...), template: str = Fo
         selected = random.sample(files, min(len(files), 17))
         for name in selected:
             shutil.copy(os.path.join(asset_dir, name), os.path.join(assets_path, name))
+        # ensure hero_1.jpg is always available since the template references it
+        hero_image = 'hero_1.jpg'
+        if hero_image not in selected and hero_image in files:
+            shutil.copy(os.path.join(asset_dir, hero_image), os.path.join(assets_path, hero_image))
+            selected.append(hero_image)
         data['images'] = selected
 
     # render page with selected images


### PR DESCRIPTION
## Summary
- copy `hero_1.jpg` when generating lifestyle sites
- document that the lifestyle template always includes this hero image

## Testing
- `python3 -m py_compile backend/main.py`