### PR TITLE
Fix lifestyle template navigation

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -163,20 +163,31 @@ async def generate(request: Request, prompt: str = Form(...), template: str = Fo
         with open(os.path.join(assets_path, name), 'w') as f:
             f.write(content_str)
 
-    # create placeholder pages for nav links
-    pages = [
-        'who_we_are.html',
-        'waterside_retreats.html',
-        'into_the_forest.html',
-        'canada_playstay.html',
-        'promotions.html',
-        'get_in_touch.html',
-    ]
-    placeholder = "<!DOCTYPE html><html><head><meta charset='UTF-8'><title>{0}</title></head><body><h1>{0}</h1><p>Placeholder page.</p></body></html>"
-    for page in pages:
-        title = page.replace('_', ' ').replace('.html', '').title()
-        with open(os.path.join(folder_path, page), 'w') as f:
-            f.write(placeholder.format(title))
+    if template == 'hotel':
+        # create placeholder pages for nav links
+        pages = [
+            'who_we_are.html',
+            'waterside_retreats.html',
+            'into_the_forest.html',
+            'canada_playstay.html',
+            'promotions.html',
+            'get_in_touch.html',
+        ]
+        placeholder = (
+            "<!DOCTYPE html><html><head><meta charset='UTF-8'><title>{0}</title></head>"
+            "<body><h1>{0}</h1><p>Placeholder page.</p></body></html>"
+        )
+        for page in pages:
+            title = page.replace('_', ' ').replace('.html', '').title()
+            with open(os.path.join(folder_path, page), 'w') as f:
+                f.write(placeholder.format(title))
+    else:
+        # copy static lifestyle section pages
+        lifestyle_pages = ['health.html', 'pets.html', 'tech.html']
+        for page in lifestyle_pages:
+            src = os.path.join('templates', 'lifestyle', page)
+            dst = os.path.join(folder_path, page)
+            shutil.copy(src, dst)
 
     site_entry = f"{folder_name}/index.html"
     sites_data.append({'prompt': prompt, 'file': site_entry})

--- a/templates/lifestyle/health.html
+++ b/templates/lifestyle/health.html
@@ -17,7 +17,7 @@
   <header class="site-header">
     <div class="logo">Lifestyle</div>
     <nav class="nav-menu">
-      <a href="lifestyle_index.html">Lifestyle</a>
+      <a href="index.html">Lifestyle</a>
       <a href="health.html">Health</a>
       <a href="pets.html">Pets</a>
       <a href="tech.html">Tech</a>

--- a/templates/lifestyle/lifestyle_index.html
+++ b/templates/lifestyle/lifestyle_index.html
@@ -211,10 +211,10 @@ body {
   <header class="site-header">
     <div class="logo">{{ title }}</div>
     <nav class="nav-menu">
-      <a href="lifestyle_index.html">Lifestyle</a>
-      <a href="health.html">Health</a>
-      <a href="pets.html">Pets</a>
-      <a href="tech.html">Tech</a>
+        <a href="index.html">Lifestyle</a>
+        <a href="health.html">Health</a>
+        <a href="pets.html">Pets</a>
+        <a href="tech.html">Tech</a>
     </nav>
   </header>
 

--- a/templates/lifestyle/pets.html
+++ b/templates/lifestyle/pets.html
@@ -17,7 +17,7 @@
   <header class="site-header">
     <div class="logo">Lifestyle</div>
     <nav class="nav-menu">
-      <a href="lifestyle_index.html">Lifestyle</a>
+      <a href="index.html">Lifestyle</a>
       <a href="health.html">Health</a>
       <a href="pets.html">Pets</a>
       <a href="tech.html">Tech</a>

--- a/templates/lifestyle/tech.html
+++ b/templates/lifestyle/tech.html
@@ -17,7 +17,7 @@
   <header class="site-header">
     <div class="logo">Lifestyle</div>
     <nav class="nav-menu">
-      <a href="lifestyle_index.html">Lifestyle</a>
+      <a href="index.html">Lifestyle</a>
       <a href="health.html">Health</a>
       <a href="pets.html">Pets</a>
       <a href="tech.html">Tech</a>


### PR DESCRIPTION
## Summary
- fix nav links in lifestyle pages to use `index.html`
- copy lifestyle page templates when generating a lifestyle site

## Testing
- `python3 -m py_compile backend/main.py`