### PR TITLE
Add comparison template support

### DIFF
--- a/templates/comparison/comparison_index.html
+++ b/templates/comparison/comparison_index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{ title }}</title>
+</head>
+<body>
+  <header>
+    <h1>{{ hero_heading }}</h1>
+    <p>{{ hero_text }}</p>
+  </header>
+  <main>
+    <section>
+      <h2>{{ item1_title }}</h2>
+      <p>{{ item1_text }}</p>
+    </section>
+    <section>
+      <h2>{{ item2_title }}</h2>
+      <p>{{ item2_text }}</p>
+    </section>
+    <section>
+      <h2>{{ conclusion_title }}</h2>
+      <p>{{ conclusion_text }}</p>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- enable comparison site generation with a new system message
- pick the comparison HTML template and bypass asset copy logic
- add simple comparison template

## Testing
- `python -m py_compile backend/main.py`