### PR TITLE
Add comparison preview template

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,8 @@ found in this file, the stored JSON is reused instead of requesting new content
 from the API. Any new completions are written back to the cache automatically.
 
 OPENAI_API_KEY=your-key-here uvicorn backend.main:app --reload
+
+### Template Previews
+
+Use `/preview/{template}` to see a demo of any built-in template. Available
+options are `hotel`, `lifestyle`, and `comparison`.

--- a/backend/main.py
+++ b/backend/main.py
@@ -221,8 +221,21 @@ async def download_site(folder: str):
 
 @app.get('/preview/{template}', response_class=HTMLResponse)
 async def preview_template(template: str):
-    if template not in {'hotel', 'lifestyle'}:
+    if template not in {'hotel', 'lifestyle', 'comparison'}:
         return HTMLResponse('Template not found', status_code=404)
+
+    if template == 'comparison':
+        demo = {
+            'title': 'Demo Site',
+            'hero_heading': 'Welcome!',
+            'comparison1': 'First option',
+            'comparison2': 'Second option',
+            'comparison3': 'Third option',
+            'comparison4': 'Fourth option',
+            'comparison5': 'Fifth option',
+        }
+        html = templates.get_template('comparison/comparison_index.html').render(**demo)
+        return HTMLResponse(html)
 
     demo = {
         'title': 'Demo Site',

--- a/templates/comparison/comparison_index.html
+++ b/templates/comparison/comparison_index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{ title }}</title>
+  <style>
+    body { font-family: Arial, sans-serif; padding: 2rem; }
+    h1 { margin-bottom: 1.5rem; }
+    ul { list-style: disc; padding-left: 2rem; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>{{ hero_heading }}</h1>
+  </header>
+  <main>
+    <ul>
+      <li>{{ comparison1 }}</li>
+      <li>{{ comparison2 }}</li>
+      <li>{{ comparison3 }}</li>
+      <li>{{ comparison4 }}</li>
+      <li>{{ comparison5 }}</li>
+    </ul>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- allow previewing the `comparison` template
- implement demo vars for comparison preview
- add a simple comparison template
- document preview routes in the README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
