### PR TITLE
Add bootstrap icons to comparison pages

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -15,6 +15,32 @@ import random
 IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.webp'}
 
 
+ICON_KEYWORDS = {
+    'phone': 'phone',
+    'laptop': 'laptop',
+    'camera': 'camera',
+    'watch': 'smartwatch',
+    'tv': 'tv',
+    'television': 'tv',
+    'tablet': 'tablet',
+    'headphone': 'headphones',
+    'speaker': 'speaker',
+    'printer': 'printer',
+    'car': 'car-front',
+    'book': 'book',
+    'chair': 'chair',
+}
+
+
+def choose_icon(name: str) -> str:
+    """Return a bootstrap icon name based on keywords in *name*."""
+    lowered = name.lower()
+    for key, icon in ICON_KEYWORDS.items():
+        if key in lowered:
+            return icon
+    return 'box'
+
+
 def list_images(src: str) -> list[str]:
     """Return names of image files in *src* matching ``IMAGE_EXTS``."""
     return [
@@ -116,6 +142,10 @@ async def generate(request: Request, prompt: str = Form(...), template: str = Fo
         cache_data[key] = data
         with open(CACHE_FILE, 'w') as f:
             json.dump(cache_data, f)
+
+    if template == 'comparison':
+        data['product1_icon'] = choose_icon(data.get('product1_name', ''))
+        data['product2_icon'] = choose_icon(data.get('product2_name', ''))
     if template == 'hotel':
         template_file = 'hotel/hotel_index.html'
     elif template == 'lifestyle':
@@ -253,11 +283,13 @@ async def preview_template(template: str):
             'hero_heading': 'Welcome!',
             'hero_text': 'Sample hero text.',
             'product1_name': 'Product 1',
+            'product1_icon': choose_icon('Product 1'),
             'product1_price': '$49',
             'product1_rating': '4.5/5',
             'product1_pros': 'Fast; Reliable',
             'product1_cons': 'Expensive; Limited colors',
             'product2_name': 'Product 2',
+            'product2_icon': choose_icon('Product 2'),
             'product2_price': '$59',
             'product2_rating': '4/5',
             'product2_pros': 'Affordable; Stylish',

--- a/templates/comparison/comparison_index.html
+++ b/templates/comparison/comparison_index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{{ title }}</title>
   <link rel="stylesheet" href="/static/bootstrap/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
   <style>
     body {
       font-family: 'Segoe UI', Tahoma, sans-serif;
@@ -69,8 +70,8 @@
         <thead>
           <tr>
             <th></th>
-            <th>{{ product1_name }}</th>
-            <th>{{ product2_name }}</th>
+            <th class="text-center"><i class="bi bi-{{ product1_icon }} fs-2 d-block mb-1"></i>{{ product1_name }}</th>
+            <th class="text-center"><i class="bi bi-{{ product2_icon }} fs-2 d-block mb-1"></i>{{ product2_name }}</th>
           </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
## Summary
- include Bootstrap Icons CDN link in comparison template
- show icons above each product column
- determine icons based on product names when generating comparison pages

## Testing
- `python -m py_compile backend/main.py`
- `pytest -q` *(fails: command not found)*